### PR TITLE
Add S in eq numbers

### DIFF
--- a/05_integrated-SS-SRA/sra-supplement/description-integrated.Rmd
+++ b/05_integrated-SS-SRA/sra-supplement/description-integrated.Rmd
@@ -14,9 +14,9 @@ Rather than fitting eight population-specific models as we describe above, @stat
 
 The integrated approach we used had the following features that differed from those in the separated approach:
 
-1.  A dimension $j$ is added to nearly all quantities. E.g., $N_{y,a}$ from eqn. \@ref(eq:apportion-R) becomes $N_{y,a,j}$, and can be summed to obtain the aggregate run returning in year $y$ by $N_y =\sum_j\sum_aN_{y,a,j}$.
+1.  A dimension $j$ is added to nearly all quantities. E.g., $N_{y,a}$ from eqn. [S3](#apportion-R) becomes $N_{y,a,j}$, and can be summed to obtain the aggregate run returning in year $y$ by $N_y =\sum_j\sum_aN_{y,a,j}$.
 
-2.  The $\varepsilon_y$ term from eqn. \@ref(eq:residuals) becomes $\varepsilon_{y,j}$ and is modeled as a multivariate normal vector within a brood year:
+2.  The $\varepsilon_y$ term from eqn. [S2](#eq-residuals) becomes $\varepsilon_{y,j}$ and is modeled as a multivariate normal vector within a brood year:
 
     \begin{equation}
     \boldsymbol{\varepsilon}_{y} \sim \mathcal{MVN}\left(\mathbf{0}, \Sigma_R\right)

--- a/05_integrated-SS-SRA/sra-supplement/description-separated.Rmd
+++ b/05_integrated-SS-SRA/sra-supplement/description-separated.Rmd
@@ -19,82 +19,90 @@ The process model is intended to represent the true population dynamics (i.e., f
 This component of our state-space spawner-recruitment model specifies productivity, density-dependence, and age-at-maturity by cohort (i.e. brood year, $y$).
 Recruitment abundances of adult Chinook (i.e., the total number of adults from a given brood year that will ever return, $R_y$) were treated as unobserved states and modeled as a function of spawner abundance in year $y$ ($S_y$) assuming a @ricker-1954 spawner-recruitment relationship with serially auto-correlated log-normal process variation:
 
+<a id="eq-ricker"></a>
 \begin{equation}
 \ln(R_y) = \ln(S_y) + \ln(\alpha) - \beta S_y + v_y
-(\#eq:ricker)
+\tag{S1}
 \end{equation}
 
 where $\alpha$ is productivity (intrinsic rate of growth), $\beta$ is the magnitude of within brood year density-dependent effects and $v_y$ reflects inter-annual variation in survival from egg to adulthood, which we term "recruitment anomalies".
 This variation was assumed to follow a lag-1 autoregressive process (correlation coefficient denoted by $\phi$) over time:
 
+<a id="eq-residuals"></a>
 \begin{equation}
 \begin{aligned}
 v_y &= \phi v_{y-1} + \varepsilon_y \\
 \varepsilon_y &\sim \mathcal{N}(0, \sigma_R)
 \end{aligned}
-(\#eq:residuals)
+\tag{S2}
 \end{equation}
 
 where $\varepsilon_y$ reflects the portion of the recruitment anomaly $v_y$ that is temporally independent (i.e., white noise).
-The first seven years of recruitment states were not linked to observations of spawner abundance in the spawner-recruitment relationship (eqn. \@ref(eq:ricker)) and were modeled as random draws from a log-normal distribution with mean $\ln(R_0)$ and variance $\sigma_R^2$.
+The first seven years of recruitment states were not linked to observations of spawner abundance in the spawner-recruitment relationship (eqn. [S1](#eq-ricker)) and were modeled as random draws from a log-normal distribution with mean $\ln(R_0)$ and variance $\sigma_R^2$.
 Rather than estimating $\ln(R_0)$) as a free parameter as in @fleischman-etal-2013, we choose to follow @staton-etal-2020 and inform its value using the expected recruitment under equilibrium unfished conditions $\ln(\alpha)/\beta$ to enable more consistent comparisons between the two approaches we used.
 The number of Chinook salmon that returned to spawn in year $y$ at age $a$ ($a \in$ 4:7) was the product of the total recruitment produced by spawning that occurred in brood year $y-a$ and the proportion from brood year $y-a$ that returned at age $a$:
 
+<a id="eq-apportion-R"></a>
 \begin{equation}
 N_{y,a} = R_{y-a} p_{y-a,a}
-(\#eq:apportion-R)
+\tag{S3}
 \end{equation}
 
 where $p_{y,a}$ is the probability that a fish spawned in brood year $y$ will mature at age $a$.
 We modeled among brood year variation in maturity schedules as Dirichlet random vectors drawn form a common hyperdistribution characterized by a mean maturation-at-age probability vector ($\boldsymbol{\pi}$) and an inverse dispersion parameter ($D$):
 
+<a id="eq-dirichlet"></a>
 \begin{equation}
 p_{y,a} \stackrel{\mathrm{iid}}{\sim} \mathcal{D}(\boldsymbol{\pi}D)
-(\#eq:dirichlet)
+\tag{S4}
 \end{equation}
 
-Following @fleischman-etal-2013, we implemented the Dirichlet distribution as a mixture of several gamma distributions (see JAGS code, below). The total run in year $y$ was made up of recruitments from multiple brood years as shown in eqn. \@ref(eq:apportion-R) and was calculated as the sum of the age-specific run abundances:
+Following @fleischman-etal-2013, we implemented the Dirichlet distribution as a mixture of several gamma distributions (see JAGS code, below). The total run in year $y$ was made up of recruitments from multiple brood years as shown in eqn. [S3](#eq-apportion-R) and was calculated as the sum of the age-specific run abundances:
 
+<a id="eq-get-N-tot"></a>
 \begin{equation}
 N_{y} = \sum_{a=4}^{7} N_{y,a}
-(\#eq:get-N-tot)
+\tag{S5}
 \end{equation}
 
 Harvest in a given year ($H_y$) was modeled as the product of total run size and the harvest rate ($U_y$) experienced that year:
 
+<a id="eq-harvest"></a>
 \begin{equation}
 H_y = N_y U_y
-(\#eq:harvest)
+\tag{S6}
 \end{equation}
 
 and spawner abundance ($S_y$) was modeled as the portion of $N_y$ remaining after harvest $H_y$:
 
+<a id="eq-get-S"></a>
 \begin{equation}
 S_y = N_y (1 - U_y)
-(\#eq:get-S)
+\tag{S7}
 \end{equation}
 
-It is this spawner abundance $S_y$ (which is itself made up of fish of multiple ages from multiple brood years) that is used in eqn.\@ref(eq:ricker) to produce the recruitment abundance produced by spawning in brood year $y$.
+It is this spawner abundance $S_y$ (which is itself made up of fish of multiple ages from multiple brood years) that is used in eqn.[S1](#eq-ricker) to produce the recruitment abundance produced by spawning in brood year $y$.
 
 ### Observation model
 
 We assumed a coefficient of variation (CV) for spawner observations that was based on the CV in estimated spawner abundances derived from the run reconstruction.
 Observed spawner abundance was therefore assumed to be log-normally distributed with the CVs converted to log-normal variance following [@forbes-etal-2011]:
 
+<a id="eq-get-sigma"></a>
 \begin{equation}
 \sigma^2_{o,y} = \ln\left(\mathrm{CV}_y^2 + 1\right)
-(\#eq:get-sigma)
+\tag{S8}
 \end{equation}
 
 We assumed that harvest had a 15% CV and so harvest observations were log-normally distributed with the CV converted to log-normal variance as per eqn.
-\@ref(eq:get-sigma).
+[S8](#eq-get-sigma).
 
 Age composition by return year was assumed to be observed with multinomial sampling error, where uncertainty in age proportions in a given year was generated by specifying an "effective sample size" (ESS) of 100.
 An ESS equal to 100 is the multinomial sample size expected to produce uncertainty roughly equivalent to that which would be anticipated from the average number of fish sampled in a given year from a population with age proportions and classes similar to that of the aggregate population.
 
 ### Model fitting
 
-We fit the model described in equations \@ref(eq:ricker) through \@ref(eq:get-sigma) in a Bayesian estimation framework. The model was parameterized with the harvest rate ($U_{\mathrm{MSY}}$) and spawner abundance ($S_{\mathrm{MSY}}$) predicted to maximize long-term sustainable yield as leading parameters from which productivity ($\alpha = e^{U_{\mathrm{MSY}}}⁄(1-U_{\mathrm{MSY}})$) and magnitude of within brood-year density dependent effects ($\beta=U_{\mathrm{MSY}}⁄S_{\mathrm{MSY}}$) were calculated [@schnute-kronlund-2002]. Prior probabilities for most unknowns in the model were specified so as to be uninformative and joint posterior probability distributions for all unknowns in the model were generated using a Markov chain Monte Carlo (MCMC) procedure in the JAGS sampler (v4.3.0) interfaced through R [@plummer-2003]. See the JAGS model code below for the priors used on all parameters and the structure of the data. We ran five chains for 40,000 iterations after a burn-in of 10,000, and retained every 20th iteration. Convergence was assessed by examining the potential scale reduction factor ($\hat{R}$), which compares within-chain variance to between-chain variance to diagnose convergence, and assumed to have occurred if $\hat{R}$ was less than 1.1 [@brooks-gelman-1998].
+We fit the model described in eqns. [S1](#eq-ricker) through [S8](#eq:get-sigma) in a Bayesian estimation framework. The model was parameterized with the harvest rate ($U_{\mathrm{MSY}}$) and spawner abundance ($S_{\mathrm{MSY}}$) predicted to maximize long-term sustainable yield as leading parameters from which productivity ($\alpha = e^{U_{\mathrm{MSY}}}⁄(1-U_{\mathrm{MSY}})$) and magnitude of within brood-year density dependent effects ($\beta=U_{\mathrm{MSY}}⁄S_{\mathrm{MSY}}$) were calculated [@schnute-kronlund-2002]. Prior probabilities for most unknowns in the model were specified so as to be uninformative and joint posterior probability distributions for all unknowns in the model were generated using a Markov chain Monte Carlo (MCMC) procedure in the JAGS sampler (v4.3.0) interfaced through R [@plummer-2003]. See the JAGS model code below for the priors used on all parameters and the structure of the data. We ran five chains for 40,000 iterations after a burn-in of 10,000, and retained every 20th iteration. Convergence was assessed by examining the potential scale reduction factor ($\hat{R}$), which compares within-chain variance to between-chain variance to diagnose convergence, and assumed to have occurred if $\hat{R}$ was less than 1.1 [@brooks-gelman-1998].
 
 ### JAGS Model Code
 

--- a/05_integrated-SS-SRA/sra-supplement/results-integrated.Rmd
+++ b/05_integrated-SS-SRA/sra-supplement/results-integrated.Rmd
@@ -748,10 +748,9 @@ legend("topright", legend = names(post_list), pch = 22, col = cols$solid, pt.bg 
 
 ```
 
-
 #### Recruitment Variability
 
-*The integrated model suggested **much** higher variability in recruitment than the separated model. When this model was applied to Kuskokwim River Chinook salmon, @staton-etal-2020 also found abnormally high estimates of recruitment variability. Recall that observation variability has supposedly been partitioned away from these estimates. Also, note that lognormal standard deviations less than \~0.6 are approximately equal to coefficients of variation of the natural scale random variables, per eqn.* \@ref(eq:get-sigma)*.* *For example, a standard deviation of 0.5 is a CV of 53%, but a standard deviation of 0.8 is a CV of 95%. Estimates from the separate model approach are more on the scale of what we expect.*
+*The integrated model suggested **much** higher variability in recruitment than the separated model. When this model was applied to Kuskokwim River Chinook salmon, @staton-etal-2020 also found abnormally high estimates of recruitment variability. Recall that observation variability has supposedly been partitioned away from these estimates. Also, note that lognormal standard deviations less than \~0.6 are approximately equal to coefficients of variation of the natural scale random variables, per eqn.* [S8](#eq-get-sigma)*. *For example, a standard deviation of 0.5 is a CV of 53%, but a standard deviation of 0.8 is a CV of 95%. Estimates from the separate model approach are more on the scale of what we expect.*
 
 ```{r, fig.width = 6, fig.height = 4}
 my_par(mar = c(5,3,1,1))

--- a/05_integrated-SS-SRA/sra-supplement/results-separated.Rmd
+++ b/05_integrated-SS-SRA/sra-supplement/results-separated.Rmd
@@ -319,9 +319,10 @@ mtext(side = 2, outer = T, "Population-Specific Harvest (000s)", line = 0.8)
 
 Note that this is the scale the data are observed on, so it is informative to see how well the sum of population-specific fits match up with it. To obtain population-specific harvest values to fit to, we assumed all populations had exploitation rates equal to that observed for the aggregate population ($U_{y,o}$), and obtained observed harvest for each population ($H_{y,j,o}$) as:
 
+<a id="eq-get-Hj-obs"></a>
 \begin{equation}
 H_{y,j,o} = \frac{S_{y,j,o} - U_{y,o}}{1 - U_{y,o}}
-(\#eq:get-Hj-obs)
+\tag{S9}
 \end{equation}
 
 ```{r Harvest fit, fig.width = 6, fig.height = 4}
@@ -485,16 +486,18 @@ These relationships are posterior summaries of the aggregate population (the tot
 
 The equilibrium calculation for population-specific escapement ($S_{\mathrm{eq},j}$) at a fixed exploitation rate ($U_{\mathrm{eq}}$) is:
 
+<a id="eq-get-Seq"></a>
 \begin{equation}
 S_{\mathrm{eq},j} = S_{\mathrm{MSY},j} \frac{U_{\mathrm{MSY},j} - \ln\left(\frac{1 - U_{\mathrm{MSY},j}}{1 - U_{\mathrm{eq}}}\right)}{U_{\mathrm{MSY},j}}
-(\#eq:get-Seq)
+\tag{S10}
 \end{equation}
 
 and for equilibrium harvest ($H_{\mathrm{eq},j}$):
 
+<a id="eq-get-S-eq"></a>
 \begin{equation}
 H_{\mathrm{eq},j} = \frac{U_{\mathrm{eq}}S_{\mathrm{eq},j}}{1 - U_{\mathrm{eq}}}
-(\#eq:get-Heq)
+\tag{S11}
 \end{equation}
 
 To build the trade-off relationships, we varied the equilibrium exploitation rate, performed the calculations on each population, and then summarized quantities across populations, e.g., summing population-specific harvest to obtain an estimate of aggregate harvest. This is an effective way to estimate the escapement ($S_{\mathrm{MSY}}$) or exploitation rate ($U_{\mathrm{MSY}}$) at maximum sustained yield from the aggregate population. Contrary to what one might expect, these quantities are not the simple summation or average of the individual population-specific quantities ($S_{\mathrm{MSY},j}$ and $U_{\mathrm{MSY},j}$). Instead, the shape of the trade-off relationships depends on the relationship between productivity and population size.

--- a/05_integrated-SS-SRA/sra-supplement/yukon-ssm-full-supplement.Rmd
+++ b/05_integrated-SS-SRA/sra-supplement/yukon-ssm-full-supplement.Rmd
@@ -1,6 +1,8 @@
 ---
 title: "Chinook population diversity contributes to fishery stability and trade-offs with mixed-stock harvest in the Yukon River"
-subtitle: "Ecological Applications /n Appendix S2"
+subtitle:  |
+    | Ecological Applications
+    | Appendix S2
 author: "B.M. Connors, M. R. Siegle, J. Harding, S. Rossi, B.A. Staton, M.L. Jones, M. Bradford, R. Browne, B. Bechtol, B. Doherty, S. Cox"
 output: 
   bookdown::html_document2:


### PR DESCRIPTION
Editorial staff requested that equation numbers in our HTML supplement have "S" appended before them. 

I implented this by:

1. Replacing (e.g.,) `(\#eq:ricker)` with `\tag{S1}` 
2. Inserted a HTML link that can be hyperlinked to (e.g., `<a id="eq-ricker"></a>`)
3. Replaced bookdown cross-references (e.g., `\@ref(eq:ricker)`) with a standard Markdown hyperlink to the HTML link in (2) (e.g., `[S1](#eq-ricker)`)